### PR TITLE
Fix update lfs file content size does not match bug

### DIFF
--- a/services/repository/files/update.go
+++ b/services/repository/files/update.go
@@ -447,7 +447,10 @@ func CreateOrUpdateFile(ctx context.Context, t *TemporaryUploadRepository, file 
 			return err
 		}
 		if !exist {
-			file.ContentReader.(io.Seeker).Seek(0, io.SeekStart)
+			_, err := file.ContentReader.(io.Seeker).Seek(0, io.SeekStart)
+			if err != nil {
+				return err
+			}
 			if err := contentStore.Put(lfsMetaObject.Pointer, file.ContentReader); err != nil {
 				if _, err2 := git_model.RemoveLFSMetaObjectByOid(ctx, repoID, lfsMetaObject.Oid); err2 != nil {
 					return fmt.Errorf("unable to remove failed inserted LFS object %s: %v (Prev Error: %w)", lfsMetaObject.Oid, err2, err)

--- a/services/repository/files/update.go
+++ b/services/repository/files/update.go
@@ -447,6 +447,7 @@ func CreateOrUpdateFile(ctx context.Context, t *TemporaryUploadRepository, file 
 			return err
 		}
 		if !exist {
+			file.ContentReader.(io.Seeker).Seek(0, io.SeekStart)
 			if err := contentStore.Put(lfsMetaObject.Pointer, file.ContentReader); err != nil {
 				if _, err2 := git_model.RemoveLFSMetaObjectByOid(ctx, repoID, lfsMetaObject.Oid); err2 != nil {
 					return fmt.Errorf("unable to remove failed inserted LFS object %s: %v (Prev Error: %w)", lfsMetaObject.Oid, err2, err)


### PR DESCRIPTION
- Fix the bug when creating a lfs file.

The reason of this bug is the file.ContentReader has been used multiple times but the i of the Reader didn't been reseted.  
